### PR TITLE
use alias for k8s provider to avoid connection issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,6 +42,6 @@ module "atlantis_server" {
   providers = {
     aws        = aws.tenant
     helm       = helm
-    kubernetes = kubernetes
+    kubernetes = kubernetes.cluster
   }
 }

--- a/provider.tf
+++ b/provider.tf
@@ -8,7 +8,10 @@ terraform {
 }
 
 provider "kubernetes" {
+  # Avoid error: dial tcp 127.0.0.1:80: connect: connection refused
+  # This seems to be a random issue. Assigning an Alias to specifically pass down Provider config
   version          = "~> 1.11"
+  alias            = "cluster"
   load_config_file = false
 }
 


### PR DESCRIPTION
currently creating a secret fails with dial tcp 127.0.0.1:80: connect: connection refused
assigning an alias to specifically pass down provider config