### PR TITLE
pin k8s version to 1.10 to avoid config issue

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -12,7 +12,9 @@ provider "helm" {
 }
 
 provider "kubernetes" {
-  version = "~> 1.11"
+  # Using 1.11 or above results in:
+  # https://github.com/hashicorp/terraform-provider-kubernetes/issues/759
+  version = "1.10.0"
 }
 
 provider "aws" {


### PR DESCRIPTION
currently localhost is picked up as host. see commented issue for more details